### PR TITLE
Per column sort config

### DIFF
--- a/codebase/sources/dhtmlxgantt.js
+++ b/codebase/sources/dhtmlxgantt.js
@@ -1289,7 +1289,21 @@ gantt._init_grid = function () {
 
 		if (column == "add") {
 			this._click.gantt_add(e, this.config.root_id);
-		} else if (this.config.sort) {
+            return;
+		} 
+        
+        if (this.config.sort) {
+            var sorting_method = column;
+
+            var conf = this.config.columns.filter(function(c){ return c.name == column })[0];
+            if ( conf && conf.sort !== undefined ) {
+                sorting_method = conf.sort;
+
+                if ( ! sorting_method ) { // sort is 'false', no no sorting
+                    return
+                }
+            }
+
 			var sort = (this._sort && this._sort.direction && this._sort.name == column) ? this._sort.direction : "desc";
 			// invert sort direction
 			sort = (sort == "desc") ? "asc" : "desc";
@@ -1298,6 +1312,7 @@ gantt._init_grid = function () {
 				direction: sort
 			};
 			this.sort(column, sort == "desc");
+			this.sort(sorting_method, sort == "desc");
 		}
 	}, this);
 

--- a/codebase/sources/dhtmlxgantt.js
+++ b/codebase/sources/dhtmlxgantt.js
@@ -5744,10 +5744,13 @@ gantt.sort = function(field, desc, parent, silent) {
 		}
 
         var result = a[field] > b[field];
-        if (desc) result = !result;
         return result ? 1 : -1;
     }) : field;
 
+    if ( desc ) {
+        var original_criteria = criteria;
+        criteria = function(a,b) { original_criteria(b,a) };
+    }
 
     var els = this.getChildren(parent);
     if (els){


### PR DESCRIPTION
The change allows to configure the sorting of columns in 3 ways:

* Setting sort to `false`

            gantt.config.columns[1].sort = false

    Disable sorting for that column

* Setting sort to a function

            gantt.config.columns[1].sort = function(a,b) {
                    return weird_computation(a,b);
            };

the column will be sorted according to the provided sorting  functions.

* Setting sort to a different field of the task

            gantt.config.columns[1].sort = 'other_field';

The column will be sorted according to the values of that other field.
