### PR TITLE
Fixed issue where task id of 0 would cause Task not found error

### DIFF
--- a/codebase/sources/dhtmlxgantt.js
+++ b/codebase/sources/dhtmlxgantt.js
@@ -5188,7 +5188,7 @@ gantt._get_parent_id = function(task){
 
 gantt.getParent = function(id){
 	var task = null;
-	if(id.id){
+	if(id.id !== undefined){
 		task = id;
 	}else{
 		task = gantt.getTask(id);


### PR DESCRIPTION
Encountered an issue where setting a task id to 0 would cause an error during parsing. The statement `if(id.id)` is made which will evaluate to false, contrary to it's intention. This error will result in a series of "Task not found id=[Object object]" errors as a task object is passed to a function expecting an integer ID. Strangely enough this error only occurs intermittently, I haven't been able to track down why.  