### PR TITLE
Error PosFromDate return a void instead of number !

### DIFF
--- a/codebase/dhtmlxgantt.d.ts
+++ b/codebase/dhtmlxgantt.d.ts
@@ -2042,7 +2042,7 @@ interface GanttStatic {
 	 * gets the relative horizontal position of the specified date in the chart area
 	 * @param date a date you want to know the position of
 	*/
-	posFromDate(date: Date): void;
+	posFromDate(date: Date): number;
 
 	/**
 	 * applies the reverted changes to the gantt once again


### PR DESCRIPTION
Error PosFromDate return a void instead of number !
Be carefull too, in the profesional version too the same error  (Gantt 6.1.1 to 6.1.5)