### PR TITLE
Add export for gantt and Gantt

### DIFF
--- a/codebase/dhtmlxgantt.d.ts
+++ b/codebase/dhtmlxgantt.d.ts
@@ -2266,13 +2266,13 @@ interface GanttStatic {
 	updateTask(id: string): void;
 }
 
-declare var gantt: GanttStatic;
+export declare var gantt: GanttStatic;
 
 declare module "gantt" {
     export = gantt;
 }
 
-declare var Gantt: GanttEnterprise;
+export declare var Gantt: GanttEnterprise;
 
 declare module "Gantt" {
     export = Gantt;


### PR DESCRIPTION
In order to avoid the following,

> File 'node_modules/dhtmlx-gantt/codebase/dhtmlxgantt.d.ts' is not a module.ts(2306)

adding in export to the `gantt` and `Gantt` declarations.